### PR TITLE
ci(docs): run test/validate on every PR, not only docs paths

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,12 +14,13 @@ name: docs
 # ThobiasKnudsen/LogosLangWebsite with Contents: read & write.
 
 on:
+  # `test` and `validate` are REQUIRED status checks on the default branch, so they must
+  # report on EVERY pull request. Do NOT add a `paths:` filter here: a PR that touches no
+  # docs would then skip this workflow, leaving the required checks stuck at "Expected,
+  # waiting for status to be reported" forever and blocking the merge. `validate` is cheap
+  # and path-independent (it checks the docs tree's current state and its diff since the
+  # last release tag), so it is a fast no-op on a PR that changes no docs.
   pull_request:
-    paths:
-      - 'docs/**'
-      - '.github/scripts/docs-check.sh'
-      - '.github/scripts/docs-check.test.sh'
-      - '.github/workflows/docs.yml'
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
## Problem

`main` is guarded by a repository ruleset requiring two status checks: **`test`** and **`validate`**. Both jobs live in `docs.yml`, whose `pull_request` trigger had a `paths:` filter scoping it to `docs/**` and the docs guard scripts.

Any PR that touches no docs (e.g. #40, a `DESIGN.md` + `language_sketch.logos` change) never triggered `docs.yml`, so `test`/`validate` never reported. The ruleset then left them at **"Expected, waiting for status to be reported"** indefinitely, and the PR could never merge. This blocks *every* non-docs PR, not just #40.

## Fix

Drop the `paths:` filter from the `pull_request` trigger so `test` and `validate` run (and report) on every PR. Both are cheap and path-independent:

- `test` self-tests the docs guard script.
- `validate` checks the docs tree's current layout and its diff since the last release tag, a fast no-op on a PR that changes no docs.

The `push` trigger keeps its `docs/**` filter, since it only drives `notify-website`. A comment now explains why no `paths:` filter belongs on the PR trigger, to stop it being re-added.

## Note

This PR itself changes `.github/workflows/docs.yml`, so it triggers `test`/`validate` and can merge normally. Once it lands, other open PRs (like #40) need a re-sync with `main` (merge or rebase) so their head picks up the filter-free workflow and the checks run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
