### PR TITLE
ci(release): stop the tag gate failing on the very first release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,11 +49,21 @@ jobs:
             exit 1
           fi
           cur="${TAG#v}"
-          highest="$(git tag --list 'v*.*.*' \
-            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
-            | grep -vx "$TAG" \
-            | sed 's/^v//' \
-            | sort -V | tail -n1)"
+          # `|| true` for the same reason docs-check.sh's latest_release_tag has it:
+          # when this tag is the only one (every first release, and any release made
+          # before another tag exists), `grep -vx "$TAG"` filters everything out and
+          # exits 1, which under `set -o pipefail` aborts the assignment and fails the
+          # gate with no error message. An empty `highest` is the correct answer here,
+          # not a failure — it means there is no previous release to be newer than.
+          highest="$(
+            {
+              git tag --list 'v*.*.*' \
+                | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+                | grep -vx "$TAG" \
+                | sed 's/^v//' \
+                | sort -V | tail -n1
+            } || true
+          )"
           if [ -n "$highest" ]; then
             newest="$(printf '%s\n%s\n' "$cur" "$highest" | sort -V | tail -n1)"
             if [ "$newest" = "$highest" ]; then


### PR DESCRIPTION
Pushing `v0.0.3` failed the `gate` job with exit 1 and **no error message**, skipping `create-release`, `build`, and `notify-website`. Nothing public was published.

Neither `::error::` line fired, so the failure was in the pipeline computing the previous highest tag:

```bash
highest="$(git tag --list 'v*.*.*' | ... | grep -vx "$TAG" | ... )"
```

When the tag being released is the **only** tag, `grep -vx "$TAG"` filters everything out and exits 1. Under the step's `set -euo pipefail` that aborts the assignment and fails the job before a single check runs. An empty `highest` is the correct answer there, not a failure: it means there is no previous release to be newer than.

This is the identical trap `docs-check.sh` already documents and guards in `latest_release_tag`:

> `|| true`: with no tags grep exits 1, which under `set -o pipefail` would abort the script inside the `r="$(latest_release_tag)"` assignment.

Same fix. It fires on every first release, which is why it survived until the first one.

## Verified

| tags present | result |
|---|---|
| only `v0.0.3` | exit 0, "previous highest: none" |
| `v0.0.2` + `v0.0.3` | exit 0, "previous highest: v0.0.2" |
| `v0.1.0` + `v0.0.3` | exit 1, "not newer than the latest release 'v0.1.0'" |

Tested by extracting the step's script straight out of the workflow YAML and running it against throwaway repos, so the tested text is the shipped text.

After merge the `v0.0.3` tag gets re-pointed at the new main commit to re-trigger the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)