### PR TITLE
Ship as v0.0.4, and document why a version tag is one-way

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,25 @@
 - When a conflict is ruled on, or a design is rejected in conversation, record it in the same session: in DESIGN.md (the existing pattern: "Recorded as rejected, to stay rejected: …") or, if spec wording must wait, as an explicit pending-spec-edit in the session log AND auto-memory. An unrecorded decision is a future bug.
 - Before starting work in a spec area not touched recently, run /faithfulness-audit.
 
+# Release rules (a version tag is one-way):
+
+**Release tags are immutable. Pushing one is irreversible, so a tag that fails CI burns that version number forever.**
+
+The `freeze-release-tags` ruleset blocks both `deletion` and `update` on every `refs/tags/v*`. A pushed tag cannot be moved or removed by anyone short of editing the ruleset in repo settings. This is deliberate: a released version must always mean one commit. The consequence is that `git push origin vX.Y.Z` is a one-way door — if the release workflow then fails, the tag stays pinned to the broken commit, the version is spent, and the next attempt must use a **new, strictly higher** version. (This is exactly how v0.0.3 was lost: the `gate` job died on a first-release-only bug, and v0.0.4 shipped the identical tree.)
+
+A spent version also freezes its docs. `docs-check.sh validate` treats any `docs/vX.Y.Z/` at or below the newest tag as frozen and fails the PR on any add, modify, or delete inside it — so the abandoned version's docs folder can no longer be removed either, and its replacement must be a copy under the new version.
+
+Before pushing any version tag:
+
+1. `cargo test --release --manifest-path seed/Cargo.toml` is green.
+2. `bash .github/scripts/docs-check.sh validate` passes.
+3. `bash .github/scripts/docs-check.sh release vX.Y.Z` passes — this is the exact check the `gate` job runs, and the in-progress `docs/vX.Y.Z/` folder must be named for the version being released.
+4. `bash .github/scripts/docs-check.test.sh` passes (the guard's own self-test).
+5. The tag is on `main`, and `main` is already merged and green. `main` is protected: it takes a PR with 2 required checks, never a direct push.
+6. Rehearse the archive: build the seed, stage `bin/logos` with LICENSE, NOTICE, TRADEMARK.md and examples, pack it, unpack it, and run it. What ships must have been run.
+
+Never tag speculatively "to see if CI passes". There is no undo.
+
 # Follow logging rules faithfully:
 - At session start create a file under CLAUDE_LOG folder with the name Session_YYYY-MM-DD_HH:mm:ss.md. 
 - What should be said in the start of the file is the session id so that Claude can find the actual session later for more details. Format like this «# Session id: [session id]»

--- a/README.md
+++ b/README.md
@@ -44,6 +44,23 @@ The same loop, written the obvious way in each language, measured on one core of
 
 Reading the table: interpreted Logos sits in CPython's class (slightly ahead on this loop) while staying a graph walk over fully reflectable structure, and one `.compile()` call puts the same function within about 1.5x of Rust's scalar code and 3x of vectorized C. The remaining gap to Rust is loop shape (Cranelift does not yet rotate loops) and the gap to C is vectorization: both are backend work, not language overhead. Absolute numbers vary with hardware; the ratios are the point.
 
+## Releasing
+
+Pushing a `vX.Y.Z` tag to `main` builds the per-OS/arch archives, creates the GitHub Release, and freezes `docs/vX.Y.Z/`.
+
+**A version tag is a one-way door.** The `freeze-release-tags` ruleset blocks deletion *and* update on every `refs/tags/v*`, so a tag cannot be moved or removed once pushed. If the release workflow fails after the tag lands, that version number is spent: the tag stays pinned to the broken commit and the next attempt must use a strictly higher version. The abandoned version's `docs/` folder is frozen too, since `docs-check.sh` refuses any change at or below the newest tag, so its replacement has to be a copy under the new version. v0.0.3 was lost this way, and v0.0.4 shipped the identical tree.
+
+So run the gates locally before tagging, never to find out whether they pass:
+
+```
+cargo test --release --manifest-path seed/Cargo.toml
+bash .github/scripts/docs-check.sh validate
+bash .github/scripts/docs-check.sh release vX.Y.Z   # the exact check the gate job runs
+bash .github/scripts/docs-check.test.sh
+```
+
+`main` is protected and takes a PR with required checks, never a direct push.
+
 ## License and credit
 
 LogosLang is free and open source under the **Apache License 2.0**. You may use, modify, build on, and redistribute it, including commercially, as long as you keep the required notices.

--- a/docs/v0.0.4/getting-started/install.md
+++ b/docs/v0.0.4/getting-started/install.md
@@ -1,0 +1,80 @@
+---
+title: Install and run
+---
+
+# Install and run
+
+Builds for macOS, Linux, and Windows are on the
+[downloads page](https://logoslang.dev/download/), and every release is also on
+[GitHub](https://github.com/ThobiasKnudsen/LogosLang/releases). Each archive
+unpacks to a `bin/logos` you can run in place; there is nothing to install.
+
+```
+curl -fsSL <asset-url> -o logos.tar.gz && tar -xzf logos.tar.gz
+./logos-<version>-<os>-<arch>/bin/logos --help
+```
+
+## Running code
+
+There is no `main`, no project file, and no build flags. A file's top-level scope
+evaluates in order and its tail expression is the file's value:
+
+```
+logos file.logos    # run a file top to bottom
+logos               # start the REPL, one expression per line, ctrl-d to exit
+```
+
+```logos
+# answer.logos
+double := fn (x : i32) -> i32 ( x + x )
+sum := i32 0
+for i in 0..7 ( sum = sum + i )
+double(sum)         # 42
+```
+
+Compilation is directed by the code rather than by the command line. Call
+`.compile()` on a function and the next call jumps to installed machine code:
+
+```logos
+sum_to := fn (n : i64) -> i64 (
+    i := i64 0
+    s := i64 0
+    while (i < n) (
+        s = s + i
+        i = i + 1
+    )
+    s
+)
+sum_to.compile()
+sum_to(1000000)
+```
+
+## What this release actually runs
+
+This is the **bootstrap seed**: a Rust program that parses source into the Logic
+Graph, interprets it, and lowers explicitly compiled functions to Cranelift. It
+is the fixed reference point the rest of the system is built on, not the finished
+language. What runs today:
+
+- the synolon cell, `logos` as a first-class value, `.logos` reflection, and
+  logos identity comparison;
+- declaration and reassignment (`:`, `:=`, `=`), juxtaposition, and `,`;
+- integer, float, and boolean primitives with casts, and comptime rationals;
+- `if`, `while`, `for`, functions, and scopes;
+- `-> logos` functions resolved at comptime, dependent declarations
+  (`a : metalogos(2)`), and a comptime `if` that drops untaken branches unparsed;
+- the [drop model](../reference/memory): `alloc`, `own`, `drop`, `free`, `defer`;
+- `.compile()` and the deoptimizing JIT;
+- the REPL, which rolls back a failed line's declarations.
+
+Not in this release, and specified rather than built: the borrow checker,
+`mut` and the other read/write gates, refinement logos, the SMT and proof layers,
+the rewriting engine, the standard library, I/O, and self-hosting. Pages that
+describe those say so where they do. A program's value is printed as a stand-in
+for I/O, so a string has nothing to print through yet.
+
+The seed also ships every primitive as `native` — callable machine code, opaque
+to reflection. Reflectability is reached incrementally: each primitive becomes
+readable as Logic Graph only once it is ported to Logos source, so the promise
+that the system reflects its own logic in full is true at the self-hosted end
+state, not at this one.

--- a/docs/v0.0.4/getting-started/introduction.md
+++ b/docs/v0.0.4/getting-started/introduction.md
@@ -1,0 +1,62 @@
+---
+title: Introduction
+---
+
+# Introduction
+
+Logos is a self-hosting systems language built on one commitment: **radical
+unification**. Programs, logos, proofs, compilation rules, the optimizer, the
+standard library, and the compiler's own logic all live in one structure the
+language can read and rewrite: the **Logic Graph**.
+
+## The synolon: one cell, two slots
+
+Every cell in the Logic Graph is a **synolon**, and a synolon is exactly two
+slots: a **logos** and a **hyle**. The logos classifies; the hyle is the raw
+substance being classified. The logos defines how the hyle is read, so a hyle
+always carries a logos, while a logos is an ordinary value that can stand on its
+own.
+
+`logos` is one identity, not three. What other languages split into a *type*
+(classification), a *struct* (a derived layout), and a *language* or *namespace*
+(a bag of definitions) is a single thing here. The difference between those cases
+is only which members vary per value: members that can change are per-instance
+and give you a record layout, members that never change are stored once with the
+logos itself, and a logos whose members are *all* shared is a pure namespace.
+
+```logos
+x := i32 5
+
+x.logos == i32       # true: x was built as an i32
+i32.logos == logos   # true: a logos's own logos is the `logos` root
+```
+
+A logos is a value, so it flows through `:=`, `==`, and function returns like
+anything else, and the classifier tower terminates at the `logos : logos`
+self-loop.
+
+## One evaluation rule
+
+To evaluate a synolon, read its logos. If that logos is a function, invoke it on
+the synolon's hyle; otherwise the synolon is data, read through its logos's
+layout. Everything runnable is a function, operators and control flow included.
+
+Operands arrive unevaluated, so control flow needs no special form: `if` receives
+its branches as Logic Graph and evaluates only the one it takes.
+
+## Interpreted by default, compiled on request
+
+Code is interpreted directly from the graph, so interpreted code *is* its Logic
+Graph. Calling `.compile()` on a function lowers its body to machine code with
+Cranelift and installs it, and the next call jumps instead of walking the body.
+Compilation is directed in the source, never by a build flag, and a compiled
+function stays reflectable through the graph it was compiled from.
+
+## Where to go next
+
+- [Install and run](install) to get the binary and see what this release does.
+- [Declaration and assignment](../reference/operators) for the core syntax.
+- [Memory and teardown](../reference/memory) for `alloc`, `own`, `drop`, and `defer`.
+- [The Logic Graph](../guides/internals/logic-graph) for the representation itself.
+- [The rewriting engine](../guides/the-rewriting-engine) for how one operation
+  serves compiler optimization, computer algebra, and your own transforms.

--- a/docs/v0.0.4/guides/internals/logic-graph.md
+++ b/docs/v0.0.4/guides/internals/logic-graph.md
@@ -1,0 +1,93 @@
+---
+title: The Logic Graph
+---
+
+# The Logic Graph
+
+A synolon is exactly two pointers, a **logos** and a **hyle**, sixteen bytes, and
+its identity is its address rather than a stored field. The logos defines how the
+hyle is read: it specifies the synolon's layout, how it consumes surrounding
+tokens during parsing, and the IR it lowers to.
+
+Operands are not stored inline. A binary `+` is a single cell whose hyle points at
+a two-field operand record, so the operator is a higher-level identity describing
+*how to read its operands* rather than a cell that holds them. Which concrete
+machine operation runs is resolved from the operator together with the operand
+logos, not from the `+` cell alone.
+
+## One evaluation rule
+
+To evaluate a synolon, read its logos. If the logos is a function, invoke it on
+the synolon's hyle; otherwise the synolon is data, read through its logos's
+layout. Everything runnable is a function, operators and control flow included.
+
+Control flow works as a function precisely because operands arrive
+*unevaluated*: a function receives its operand record as Logic Graph and decides
+what to evaluate, so `if` runs its condition and then only the taken branch.
+Laziness is what the substrate gives by default, not a special form.
+
+## A logos's metadata is shared; its per-value data is not
+
+A logos stores its `precedence`, `associativity`, `constructor`, and `destructor`
+once and shares them across every value of that logos. The bytes that differ per
+value are the per-instance fields.
+
+Placement is decided by mutability rather than annotation. A member that can ever
+change is per-instance, and a member that never changes is identical across every
+instance and stored once with the logos. That single partition is why the record
+case and the authored case are one identity: a logos whose constructor derives its
+layout from the field declarations in its scope is what other languages call a
+struct, a logos whose members are all shared is a namespace, and neither needs a
+second mechanism.
+
+## Uniform model, non-uniform storage
+
+Every identity *has* a permission and a lifetime in the model; almost none *store*
+one. The cell stays lean at its two slots, metadata hangs off only on deviation,
+and defaults are inherited from the scope tree. The common case, immutable
+`'static` definitions such as operators, logos, and the standard library, shares
+one default of readable-by-all with no lifetime tracking, no drop node, and no
+borrow state. Storage is proportional to *deviations*, not to identity count,
+which is what makes a uniform model affordable.
+
+## Parsing is the constructors driving a tape
+
+There is no parse-then-run step. Source is converted to synolons one token at a
+time and the graph is interpreted directly.
+
+Two states stand at every source index: the **parsing tape** and the growing
+Logic Graph. The tape is the working frontier, holding both the synolons reduced
+so far but not yet final and the tokens still to consume, the latter lexed lazily
+on demand, so lexing and parsing are one pass that the constructors drive rather
+than two.
+
+Each logos's `constructor` reads forward on the tape for the tokens it consumes
+and back on the tape for its left context. When precedence guarantees a cluster
+will consume no more tokens it is final, so it detaches from the tape and attaches
+at the current location in the graph. A constructor edits the tape *in place*, and
+the driver decides only *when* constructors run, never what they leave.
+
+The tape carries `insert` and `remove`, and that is the whole macro and
+custom-syntax mechanism: a syntactic abstraction is a constructor rewriting the
+token stream over real synolons, not a macro sublanguage. The tape is therefore
+not a private parser structure but Logic Graph with a string extension, since a
+reduced cell is a graph synolon already and a token cell is a synolon-in-waiting.
+Reflecting on it needs no second metalanguage.
+
+## Compilation is a reader of frozen structure
+
+Interpreted code *is* its Logic Graph. A compiled artifact is a long-lived
+*reader* of a subgraph's structure, and what licenses it is the absence of any
+structural writer over that region for the artifact's lifetime.
+
+So the rule that a graph mutation invalidates outstanding readers *is*
+deoptimization: a structural write to compiled code drops the artifact and falls
+back to interpretation, while ordinary runtime values flow through unaffected,
+because what froze is the code's structure and not its data. This is also why a
+JIT-compiled region stays fully reflectable through the graph it was compiled
+from.
+
+This release does not promote automatically. It interprets everything and
+compiles only what the source directs with `f.compile()`; scope-granular backend
+markers and profile-driven promotion are later work riding the same deopt
+boundary.

--- a/docs/v0.0.4/guides/the-rewriting-engine.md
+++ b/docs/v0.0.4/guides/the-rewriting-engine.md
@@ -1,0 +1,44 @@
+---
+title: The rewriting engine
+---
+
+# The rewriting engine
+
+> Specified, not in this release. See
+> [what this release runs](../getting-started/install).
+
+Logos collapses three things other languages keep apart (compiler optimization,
+computer algebra, and user-defined transformation) into one operation: take a
+Logic Graph or Logos IR fragment, apply rewrite rules, and extract the form that
+minimizes a cost function.
+
+The engine uses **equality saturation**. Rather than rewriting destructively in
+priority order, it builds an e-graph of the forms equivalent to the input under
+the rule set, then extracts the lowest-cost one. Extraction is optimal over the
+forms the e-graph actually holds; a true fixpoint is not guaranteed, since
+size-increasing rules can grow the e-graph without bound, so the engine runs
+under an explicit iteration, size, and time budget and extracts the best form
+found within it.
+
+Rule sets and cost functions are ordinary, first-class Logos values, so a
+compiler optimization pass is a library rather than special compiler code.
+
+```logos
+eval(optimize_for(target, kernel))   # target-specific rewriting, at compile time
+```
+
+A cost function maps Logic Graph nodes to costs. The standard library is to ship
+FLOP count, numerical stability, code size, register pressure, and target-specific
+metrics; users supply their own. The different jobs people want from a rewriter
+are then just a choice of cost function or rule subset: minimum-cost (the default
+`simplify`), canonical (equality testing), factored, expanded, numerically stable,
+or target-specific.
+
+The same engine serves the compiler's `x + 0 → x` and the mathematician's
+`sin²(θ) + cos²(θ) → 1`.
+
+The freeze that licenses compilation is the same one that licenses this:
+equality saturation needs a fixed input, so compiling a region, optimizing it,
+and extracting a cheaper proven-equivalent variant are one operation under one
+condition, that no live structural writer exists over the region. See
+[the Logic Graph](internals/logic-graph) for that boundary.

--- a/docs/v0.0.4/reference/memory.md
+++ b/docs/v0.0.4/reference/memory.md
@@ -1,0 +1,107 @@
+---
+title: Memory and teardown
+---
+
+# Memory and teardown
+
+Locals are scope-bound and their memory is reclaimed with the frame, an
+effect-free bulk operation. There is no GC. Reclamation and destruction are
+distinct: returning memory that needs no teardown stays implicit, while running
+teardown never is.
+
+## The constructor authors the teardown
+
+`alloc T v` returns an owning pointer `@T`. What frees it is never an invisible
+scope-end rule. Only the construction site knows how a value was built, which
+allocator it came from, and what invariants hold, so **the constructor writes the
+teardown and inserts it as reflectable `defer` structure** into the scope where
+the result's ownership lands:
+
+```logos
+a := alloc i32 40   # inserts `defer free a` into this scope
+a@                  # 40
+```
+
+`alloc` is only the first instance of the general rule. Any constructor may
+insert its paired teardown, so a file-opening constructor inserts its
+`defer close`, and a record logos's derived constructor composes the teardowns
+its field definitions declare. Deconstruction has too many shapes for one
+mechanism to know them all; each constructor knows its own.
+
+`defer` runs LIFO at scope exit, so teardown order reverses construction order.
+Because teardown is ordinary graph structure rather than hidden drop glue,
+"every `alloc` reaches a paired `free` on every path" is a proposition over the
+graph that the proof layer can discharge like any other.
+
+Recorded as rejected, to stay rejected: implicit scope-end destruction in any
+form, and `:=` inserting `defer drop` on every declaration. Declaration stays
+neutral; teardown authorship belongs to constructors alone.
+
+## `own`, `drop`, and the cancelled defer
+
+`own` and `drop` are **takes**: they consume, emptying the source. A pending
+deferred teardown over an emptied place is a sanctioned no-op, which is what
+cancels the inserted `defer` on an early `drop` and on transfer of ownership out
+of a scope, with no graph edit:
+
+```logos
+a := alloc i32 40
+b := own a          # ownership moves to b; a's pending free no-ops
+b@                  # 40
+```
+
+```logos
+a := alloc i32 5
+v := a@
+drop a              # runs a's destructor now; the scope-exit free no-ops
+v                   # 5
+```
+
+A borrow mints the same `@T` with a null destructor, so owning-ness rides the
+node `alloc` built rather than `@T` in general:
+
+```logos
+x := i32 3
+p := &x
+p@                  # 3, and p owns nothing
+```
+
+## Three rules that keep ownership from escaping
+
+Each is a place where ownership would otherwise slip past the machinery that
+frees it, so each fails closed:
+
+1. **An owning value must be bound to a name**, which is where its `free`
+   attaches. `f(alloc i32 5)` is refused rather than leaked; bind it first and
+   pass the name.
+2. **A scope's value may not be a place that scope owns**, since the inserted
+   teardown would free it on the way out and hand back freed memory. `own` is how
+   ownership leaves a scope, so it is required.
+3. **Ownership may not cross a function return.** A block hands ownership to its
+   binder in full view of the parse, but a call hides its body behind a return
+   logos that cannot yet say it transfers ownership, so the caller would not know
+   it owes a `free`.
+
+The third lifts once a logos can carry its ownership mode, which is the
+ownership-gate work: `take` and `drop` as gates on a reference, the same
+primitive as `pub` and `mut`.
+
+## Standing approximations
+
+Two pieces of machinery are not built yet, and this release stands in for them:
+
+- The *emptied-to-undefined* flag is a **null pointer** written into the place.
+  The seed has no phase bits, so a deferred teardown over a null place is exactly
+  the sanctioned no-op.
+- Teardown attaches at the **binding site**, so only named owning bindings are
+  covered. The attachment rule for a bare owning temporary, and the composition
+  order of field-declared teardowns, are both still open.
+
+Shared ownership is a recorded direction rather than built code: a `share`
+operator would co-own *without* emptying the source, its destructor decrementing
+a reference count and freeing at zero, on the same destructor-slot machinery this
+page already describes.
+
+`&T` and `&mut T` are statically checked, many shared XOR one exclusive, with
+lexical lifetimes. That checker is specified and not in this release; see
+[what this release runs](../getting-started/install).

--- a/docs/v0.0.4/reference/operators.md
+++ b/docs/v0.0.4/reference/operators.md
@@ -1,0 +1,96 @@
+---
+title: Declaration and assignment
+---
+
+# Declaration and assignment
+
+A synolon is a **logos** slot and a **hyle** slot, and declarations are immutable
+by default. Three operators write those slots.
+
+| Operator | Meaning | Example |
+| --- | --- | --- |
+| `:` | **Declare**: introduce a name and set its logos slot, leaving the hyle undefined | `a : i32` |
+| `:=` | **Declare with a value**: introduce a name and set its hyle slot, inferring the logos | `a := 32` |
+| `=` | **Reassign** the hyle of an already-declared name | `a = a + 1` |
+
+The colon writes the logos slot; the other two write the hyle slot. They do not
+compose: `a : i32 = 5` is rejected. A name declared with a logos takes its value
+by later reassignment.
+
+```logos
+a : i32
+a = 7
+a           # 7
+```
+
+`=` is reassignment, not declaration. It is an error on a name that was never
+declared, so a mistyped `cont = 6` is caught rather than silently bound.
+
+## Juxtaposition
+
+An anonymous value with its logos is written by **juxtaposition**, the logos
+preceding the hyle: `i32 32`, `f64 2.0`. There is no `logos = value` form.
+
+The two declaration operators differ in what they accept. `:` requires its
+operand to *be* a logos, since that is what a logos slot holds. `:=` accepts any
+synolon at all, a logos included, because a logos is a value like any other:
+
+```logos
+x := i32    # binds the name to the logos itself
+y := x 5    # so x is another spelling of i32
+y           # 5
+```
+
+## `,` is the one explicit separator
+
+Expressions are self-delimiting: a cluster detaches the moment precedence
+guarantees it will consume no more tokens, and that is also what ends each
+expression. Newlines are ordinary whitespace and `;` does not exist.
+
+Separation is required only where adjacency would otherwise read as consumption,
+which is where a logos sits before a value it must not take:
+
+```logos
+f := fn (a : i32, b : i32) -> i32 ( a + b )
+f(i32 3, 4)   # 7: one anonymous i32 value, then a literal
+```
+
+`f(i32 3)` would instead be a *single* argument, juxtaposition having consumed
+the `3`. The same `,` separates fields, arguments, and expressions, and may also
+be written where nothing is ambiguous, purely for the reader.
+
+## Comments are graph structure
+
+`#` is an ordinary identity that consumes either the rest of the line or a
+following `«…»` string, and builds a reflectable comment node interleaved with
+the code it annotates. Documentation is extracted by graph query rather than by
+scraping syntax. A comment node is void-valued and invisible to value flow, so a
+trailing `# done` never becomes a scope's value.
+
+```logos
+x := i32 1  # trailing prose, and x is still the value
+x           # 1
+```
+
+## `mut` is a logos modifier
+
+> Specified, not in this release. The seed has no `mut`; every declaration is
+> immutable and reassignment writes the hyle directly. See
+> [what this release runs](../getting-started/install).
+
+Mutability is something the *logos* states about the value, not a qualifier in
+value position: `mut T` is the logos of a mutable T, the very same `mut` as in
+`&mut T`. `mut` left-prefixes a logos at any level of the classifier tower and
+makes the level just below it mutable, so the two slots are independent
+permissions and a value construction spells out four states:
+
+```logos
+i32 32                # frozen logos, frozen hyle    : a plain constant
+mut i32 32            # frozen logos, mutable hyle   : an ordinary variable
+mut logos i32 32      # mutable logos, frozen hyle   : reinterpret-only
+mut logos mut i32 32  # both                         : full structural mutability
+```
+
+A mutable logos does not imply a mutable hyle; reinterpret-only is its own
+quadrant. Both slots follow one lifecycle, `undefined` to defined to frozen, and
+the flip to frozen is one-way.


### PR DESCRIPTION
## Why v0.0.4 and not v0.0.3

The `v0.0.3` tag landed **before** the gate fix in #55. The `freeze-release-tags` ruleset blocks both `deletion` and `update` on every `refs/tags/v*`:

```json
{"conditions":{"ref_name":{"include":["refs/tags/v*"]}},"rules":["deletion","update"]}
```

So the tag is pinned to 8990d18 permanently, and the release workflow at that commit fails permanently. The version is spent. `v0.0.4` ships the identical tree.

`docs/v0.0.3` cannot be removed either: with `v0.0.3` tagged, `docs-check.sh`'s freeze guard treats that folder as released and fails the required `validate` check on any add, modify, or delete inside it. `docs/v0.0.4` is therefore an exact copy, verified with `diff -r`, and `docs/v0.0.3` remains as a tagged snapshot that never shipped a binary.

## Documentation

Both files gain the rule, so the next person does not rediscover it by burning another version:

- **CLAUDE.md** — a `Release rules` section: the one-way-door property, that a failed release also freezes that version's docs folder, a six-item pre-tag checklist, and "never tag speculatively to see if CI passes. There is no undo."
- **README.md** — a `Releasing` section with the same warning and the four commands to run locally before tagging.

## Gates run locally before pushing

| check | result |
|---|---|
| `cargo test --release` | 218 + 34 green |
| `docs-check.sh validate` | OK (R = v0.0.3) |
| `docs-check.sh release v0.0.4` | OK |
| `docs-check.test.sh` | 10 passed, 0 failed |
| release.yml YAML parse | OK |

Tag `v0.0.4` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)